### PR TITLE
Added repository and bug tracking fields for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "homebridge-vizio",
   "version": "1.0.1",
   "description": "Control your Vizio Smartcast display from HomeKit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JohnWickham/homebridge-vizio.git"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -17,6 +21,9 @@
   },
   "author": "Wick",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/JohnWickham/homebridge-vizio/issues"
+  },
   "dependencies": {
     "vizio-smart-cast": "^1.2.0",
     "readline": "^1.3.0"


### PR DESCRIPTION
Currently, searching for `homebridge-vizio` on Google only shows your NPM page, not this repository. Adding these fields will provide links and issue statistics on the NPM page.

Also, your plug-in seems to work much more reliably than the previous one I was using, so thank you for your work! 🎉